### PR TITLE
feat(P1-T1): add OTel Collector configuration

### DIFF
--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -1,0 +1,37 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+
+exporters:
+  prometheusremotewrite:
+    endpoint: http://prometheus:9090/api/v1/write
+    resource_to_telemetry_conversion:
+      enabled: true
+
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheusremotewrite]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/loki]


### PR DESCRIPTION
OTLP receiver (gRPC :4317, HTTP :4318), batch processor (5s/1024), prometheusremotewrite exporter for metrics, otlphttp exporter for logs → Loki OTLP endpoint, health_check extension on :13133.

Uses otlphttp/loki instead of the deprecated loki exporter, targeting Loki's native OTLP ingestion endpoint (/otlp) for Loki 3.x compat.